### PR TITLE
Missing page icons

### DIFF
--- a/bar-chart.html
+++ b/bar-chart.html
@@ -11,6 +11,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bar Chart</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.3/Sortable.min.js"></script>
     <style>

--- a/graph-view.html
+++ b/graph-view.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <title>Mermaid-like Graph Visualizer</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
 
 <!-- 
 Changes requested:

--- a/location-generator.html
+++ b/location-generator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Random Location Generator</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
     <style>
         /* Mobile-first CSS with emphasis on touch-friendly interface and easy coordinate copying */
         * {

--- a/pizza.html
+++ b/pizza.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Pizza Property Preference Picker</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
   <!-- Google Font for a modern look -->
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">

--- a/priorities.html
+++ b/priorities.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Weekly Priorities Planner</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
   <style>
     /* Base styling */
     body {

--- a/rhymes.html
+++ b/rhymes.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Rhyme Practice</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
   <style>
     /* ---- DARK THEME ---- */
     * {

--- a/rhymes2.html
+++ b/rhymes2.html
@@ -29,6 +29,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Rhyme Practice</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
   
   <!-- React and Babel for in-browser transpilation -->
   <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>

--- a/save-tab/popup.html
+++ b/save-tab/popup.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Save Tab Info</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
     <style>
       body {
         font-family: Arial, sans-serif;

--- a/venn-diagram.html
+++ b/venn-diagram.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Interactive Venn Diagram</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
         :root {

--- a/workout.html
+++ b/workout.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Workout Rep Counter</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231f2937'/%3E%3Ccircle cx='32' cy='32' r='14' fill='%233498db'/%3E%3C/svg%3E">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>


### PR DESCRIPTION
Add a consistent favicon to all HTML pages because they previously lacked icons.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a2ee6488-14a9-461d-bddc-cebcee9d4812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a2ee6488-14a9-461d-bddc-cebcee9d4812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely a static UI metadata change (favicon) with no impact on application logic or data handling.
> 
> **Overview**
> Adds a consistent inline SVG favicon (`<link rel="icon" ...>`) to the `<head>` of multiple standalone HTML tools/pages (e.g., `bar-chart.html`, `graph-view.html`, `location-generator.html`, `pizza.html`, `priorities.html`, `rhymes*.html`, `venn-diagram.html`, `workout.html`, and `save-tab/popup.html`) so browser tabs show an icon.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5277392fa40dca5cfc27127aaaead243f910f052. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->