### PR TITLE
Generator destination input

### DIFF
--- a/location-generator.html
+++ b/location-generator.html
@@ -849,42 +849,28 @@
         }
 
         /**
-         * Product requirement: include explicit start (origin) and destination in Apple Maps directions.
-         * Uses maps:// URL scheme to launch the native Apple Maps app instead of the web page.
+         * Only pass the destination so the maps app uses current GPS as start,
+         * which enables the "Start driving" button instead of a step list.
+         * Uses maps:// URL scheme to launch the native Apple Maps app.
          */
         function startAppleMapsNavigation(lat, lng) {
             assert(Number.isFinite(lat) && Number.isFinite(lng), 'Navigation destination must be finite coordinates');
 
             const params = new URLSearchParams();
-            const origin = getOrigin();
-
-            if (origin !== null) {
-                const hasFiniteOrigin = Number.isFinite(origin.lat) && Number.isFinite(origin.lng);
-                assert(hasFiniteOrigin, 'Navigation start coordinates must be finite');
-                params.set('saddr', `${origin.lat},${origin.lng}`);
-            }
-
             params.set('daddr', `${lat},${lng}`);
             params.set('dirflg', 'd');
             window.location.href = `maps://?${params.toString()}`;
         }
 
         /**
-         * Product requirement: Android-friendly option using Google Maps direction URLs.
+         * Only pass the destination so Google Maps uses current GPS as start,
+         * which enables the "Start driving" button instead of a step list.
          */
         function startGoogleMapsNavigation(lat, lng) {
             assert(Number.isFinite(lat) && Number.isFinite(lng), 'Navigation destination must be finite coordinates');
 
             const googleMapsURL = new URL('https://www.google.com/maps/dir/');
             googleMapsURL.searchParams.set('api', '1');
-
-            const origin = getOrigin();
-            if (origin !== null) {
-                const hasFiniteOrigin = Number.isFinite(origin.lat) && Number.isFinite(origin.lng);
-                assert(hasFiniteOrigin, 'Navigation start coordinates must be finite');
-                googleMapsURL.searchParams.set('origin', `${origin.lat},${origin.lng}`);
-            }
-
             googleMapsURL.searchParams.set('destination', `${lat},${lng}`);
             googleMapsURL.searchParams.set('travelmode', 'driving');
             window.location.href = googleMapsURL.toString();


### PR DESCRIPTION
Remove the starting location parameter from map navigation functions to allow maps apps to use the device's current GPS for 'Start driving' navigation instead of showing a list of steps.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a2fdaa86-1a7c-45f3-8d75-5a6bb9533458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a2fdaa86-1a7c-45f3-8d75-5a6bb9533458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

